### PR TITLE
Add initial support for an explicit "ManifestListTags" field

### DIFF
--- a/manifest/example.go
+++ b/manifest/example.go
@@ -20,6 +20,7 @@ Maintainers: InfoSiftr <github@infosiftr.com> (@infosiftr),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 GitFetch: refs/heads/master
+SharedTags: latest
 
 
  # hi
@@ -29,18 +30,20 @@ GitFetch: refs/heads/master
 
 
 # Go 1.6
-Tags: 1.6.1, 1.6, 1, latest
+Tags: 1.6.1, 1.6, 1
 GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
 Directory: 1.6
 
 
 # Go 1.5
 Tags: 1.5.3
+SharedTags: 1.5.3-debian, 1.5-debian
 GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
 Directory: 1.5
 
 
 Tags: 1.5
+SharedTags: 1.5-debian
 GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
 Directory: 1.5
 
@@ -50,6 +53,15 @@ Directory: 1.5
 		panic(err)
 	}
 	fmt.Printf("-------------\n2822:\n%s\n", man)
+
+	fmt.Printf("\nShared Tag Groups:\n")
+	for _, group := range man.GetSharedTagGroups() {
+		fmt.Printf("\n  - %s\n", strings.Join(group.SharedTags, ", "))
+		for _, entry := range group.Entries {
+			fmt.Printf("    - %s\n", entry.TagsString())
+		}
+	}
+	fmt.Printf("\n")
 
 	man, err = manifest.Parse(bufio.NewReader(strings.NewReader(`
 # first set

--- a/manifest/rfc2822.go
+++ b/manifest/rfc2822.go
@@ -27,7 +27,8 @@ type Manifest2822Entry struct {
 
 	Maintainers []string `delim:"," strip:"\n\r\t "`
 
-	Tags []string `delim:"," strip:"\n\r\t "`
+	Tags       []string `delim:"," strip:"\n\r\t "`
+	SharedTags []string `delim:"," strip:"\n\r\t "`
 
 	GitRepo   string
 	GitFetch  string
@@ -46,6 +47,7 @@ func (entry Manifest2822Entry) Clone() Manifest2822Entry {
 	// SLICES! grr
 	entry.Maintainers = append([]string{}, entry.Maintainers...)
 	entry.Tags = append([]string{}, entry.Tags...)
+	entry.SharedTags = append([]string{}, entry.SharedTags...)
 	entry.Constraints = append([]string{}, entry.Constraints...)
 	return entry
 }
@@ -58,6 +60,10 @@ func (entry Manifest2822Entry) MaintainersString() string {
 
 func (entry Manifest2822Entry) TagsString() string {
 	return strings.Join(entry.Tags, StringSeparator2822)
+}
+
+func (entry Manifest2822Entry) SharedTagsString() string {
+	return strings.Join(entry.SharedTags, StringSeparator2822)
 }
 
 func (entry Manifest2822Entry) ConstraintsString() string {
@@ -76,6 +82,9 @@ func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifes
 	}
 	if entry.TagsString() == defaults.TagsString() {
 		entry.Tags = nil
+	}
+	if entry.SharedTagsString() == defaults.SharedTagsString() {
+		entry.SharedTags = nil
 	}
 	if entry.GitRepo == defaults.GitRepo {
 		entry.GitRepo = ""
@@ -102,6 +111,9 @@ func (entry Manifest2822Entry) String() string {
 	}
 	if str := entry.TagsString(); str != "" {
 		ret = append(ret, "Tags: "+str)
+	}
+	if str := entry.SharedTagsString(); str != "" {
+		ret = append(ret, "SharedTags: "+str)
 	}
 	if str := entry.GitRepo; str != "" {
 		ret = append(ret, "GitRepo: "+str)
@@ -145,6 +157,16 @@ func (entry Manifest2822Entry) HasTag(tag string) bool {
 	return false
 }
 
+// HasSharedTag returns true if the given tag exists in entry.SharedTags.
+func (entry Manifest2822Entry) HasSharedTag(tag string) bool {
+	for _, existingTag := range entry.SharedTags {
+		if tag == existingTag {
+			return true
+		}
+	}
+	return false
+}
+
 func (manifest Manifest2822) GetTag(tag string) *Manifest2822Entry {
 	for _, entry := range manifest.Entries {
 		if entry.HasTag(tag) {
@@ -152,6 +174,27 @@ func (manifest Manifest2822) GetTag(tag string) *Manifest2822Entry {
 		}
 	}
 	return nil
+}
+
+// GetSharedTag returns a list of entries with the given tag in entry.SharedTags (or the empty list if there are no entries with the given tag).
+func (manifest Manifest2822) GetSharedTag(tag string) []Manifest2822Entry {
+	ret := []Manifest2822Entry{}
+	for _, entry := range manifest.Entries {
+		if entry.HasSharedTag(tag) {
+			ret = append(ret, entry)
+		}
+	}
+	return ret
+}
+
+// GetAllSharedTags returns a list of the sum of all SharedTags in all entries of this image manifest (in the order they appear in the file).
+func (manifest Manifest2822) GetAllSharedTags() []string {
+	fakeEntry := Manifest2822Entry{}
+	for _, entry := range manifest.Entries {
+		fakeEntry.SharedTags = append(fakeEntry.SharedTags, entry.SharedTags...)
+	}
+	fakeEntry.DeduplicateSharedTags()
+	return fakeEntry.SharedTags
 }
 
 func (manifest *Manifest2822) AddEntry(entry Manifest2822Entry) error {
@@ -165,13 +208,27 @@ func (manifest *Manifest2822) AddEntry(entry Manifest2822Entry) error {
 		return fmt.Errorf("Tags %q has invalid Maintainers: %q (expected format %q)", strings.Join(invalidMaintainers, ", "), MaintainersFormat)
 	}
 
+	entry.DeduplicateSharedTags()
+
 	seenTag := map[string]bool{}
 	for _, tag := range entry.Tags {
 		if otherEntry := manifest.GetTag(tag); otherEntry != nil {
 			return fmt.Errorf("Tags %q includes duplicate tag: %q (duplicated in %q)", entry.TagsString(), tag, otherEntry.TagsString())
 		}
+		if otherEntries := manifest.GetSharedTag(tag); len(otherEntries) > 0 {
+			return fmt.Errorf("Tags %q includes tag conflicting with a shared tag: %q (shared tag in %q)", entry.TagsString(), tag, otherEntries[0].TagsString())
+		}
 		if seenTag[tag] {
 			return fmt.Errorf("Tags %q includes duplicate tag: %q", entry.TagsString(), tag)
+		}
+		seenTag[tag] = true
+	}
+	for _, tag := range entry.SharedTags {
+		if otherEntry := manifest.GetTag(tag); otherEntry != nil {
+			return fmt.Errorf("Tags %q includes conflicting shared tag: %q (duplicated in %q)", entry.TagsString(), tag, otherEntry.TagsString())
+		}
+		if seenTag[tag] {
+			return fmt.Errorf("Tags %q includes duplicate tag: %q (in SharedTags)", entry.TagsString(), tag)
 		}
 		seenTag[tag] = true
 	}
@@ -179,6 +236,8 @@ func (manifest *Manifest2822) AddEntry(entry Manifest2822Entry) error {
 	for i, existingEntry := range manifest.Entries {
 		if existingEntry.SameBuildArtifacts(entry) {
 			manifest.Entries[i].Tags = append(existingEntry.Tags, entry.Tags...)
+			manifest.Entries[i].SharedTags = append(existingEntry.SharedTags, entry.SharedTags...)
+			manifest.Entries[i].DeduplicateSharedTags()
 			return nil
 		}
 	}
@@ -208,6 +267,20 @@ func (entry Manifest2822Entry) InvalidMaintainers() []string {
 		}
 	}
 	return invalid
+}
+
+// DeduplicateSharedTags will remove duplicate values from entry.SharedTags, preserving order.
+func (entry *Manifest2822Entry) DeduplicateSharedTags() {
+	aggregate := []string{}
+	seen := map[string]bool{}
+	for _, tag := range entry.SharedTags {
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		aggregate = append(aggregate, tag)
+	}
+	entry.SharedTags = aggregate
 }
 
 type decoderWrapper struct {


### PR DESCRIPTION
Things we know we'll need to be able to do with the new `ManifestListTags` (and are thus included in this initial file format support):

- get list of all manifest list tags from a manifest (`manifest.GetAllManifestListTags()`)
- get list of manifest list tags from an entry (`entry.ManifestListTags`)
- get list of entries given a manifest list tag (`manifest.GetManifestListTag(tag)`)

This is the first step towards https://github.com/docker-library/official-images/issues/2289.

An example of the expected usage (in the `hello-world` image):

```
Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
GitRepo: https://github.com/docker-library/hello-world.git

Tags: linux
ManifestListTags: latest
GitCommit: bdee60d7ff6b98037657dc34a10e9ca4ffd6785f
Directory: hello-world

Tags: nanoserver
ManifestListTags: latest
GitCommit: 1f13a5bc3b787747eeefb3b0051d8d29f851260d
Directory: hello-world/nanoserver
Constraints: nanoserver
```

And again as a `diff`, so that the actual changes are more obvious:

```diff
diff --git a/library/hello-world b/library/hello-world
index e9364fd..ef1f40c 100644
--- a/library/hello-world
+++ b/library/hello-world
@@ -4,11 +4,13 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
 
-Tags: latest
+Tags: linux
+ManifestListTags: latest
 GitCommit: bdee60d7ff6b98037657dc34a10e9ca4ffd6785f
 Directory: hello-world
 
 Tags: nanoserver
+ManifestListTags: latest
 GitCommit: 1f13a5bc3b787747eeefb3b0051d8d29f851260d
 Directory: hello-world/nanoserver
 Constraints: nanoserver
```

cc @friism @StefanScherer @yosifkit

(On the `bashbrew` side, when this change is integrated, the idea is that there will be a fourth build step after `bashbrew build`, `bashbrew tag`, and `bashbrew push` which is responsible for assembling and updating the actual manifest list objects on the Docker Hub so that it can be re-invoked as images are built and made available and the manifest list objects can be re-assembled as the artifacts they need to include actually exist.)