### PR TITLE
Add a package for converting from a "bashbrew arch" to a full OCI "platform" object (os+arch+variant)

### DIFF
--- a/architecture/oci-platform.go
+++ b/architecture/oci-platform.go
@@ -1,0 +1,25 @@
+package architecture
+
+// https://github.com/opencontainers/image-spec/blob/v1.0.0-rc6/image-index.md#image-index-property-descriptions
+// see "platform" (under "manifests")
+type OCIPlatform struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	Variant      string `json:"variant,omitempty"`
+
+	//OSVersion  string   `json:"os.version,omitempty"`
+	//OSFeatures []string `json:"os.features,omitempty"`
+}
+
+var SupportedArches = map[string]OCIPlatform{
+	"amd64":   {OS: "linux", Architecture: "amd64"},
+	"arm32v5": {OS: "linux", Architecture: "arm", Variant: "v5"},
+	"arm32v6": {OS: "linux", Architecture: "arm", Variant: "v6"},
+	"arm32v7": {OS: "linux", Architecture: "arm", Variant: "v7"},
+	"arm64v8": {OS: "linux", Architecture: "arm64", Variant: "v8"},
+	"i386":    {OS: "linux", Architecture: "386"},
+	"ppc64le": {OS: "linux", Architecture: "ppc64le"},
+	"s390x":   {OS: "linux", Architecture: "s390x"},
+
+	"windows-amd64": {OS: "windows", Architecture: "amd64"},
+}


### PR DESCRIPTION
This also includes a list of standard mappings (intended for both input validation and output conversion).

I'm not 100% sold on the package name, but it's not horrible.  It won't conflict with our global `arch` variable over in `bashbrew`, which is about the only nice property it's got.