### PR TITLE
Force line-based files to have valid "Maintainers" too

### DIFF
--- a/manifest/line-based.go
+++ b/manifest/line-based.go
@@ -80,5 +80,12 @@ func ParseLineBased(readerIn io.Reader) (*Manifest2822, error) {
 		}
 	}
 
+	if len(manifest.Global.Maintainers) < 1 {
+		return nil, fmt.Errorf("missing Maintainers")
+	}
+	if invalidMaintainers := manifest.Global.InvalidMaintainers(); len(invalidMaintainers) > 0 {
+		return nil, fmt.Errorf("invalid Maintainers: %q (expected format %q)", strings.Join(invalidMaintainers, ", "), MaintainersFormat)
+	}
+
 	return manifest, nil
 }


### PR DESCRIPTION
This copies the exact `mainfest.Global.Maintainers` validation from `rfc2822.go`.

In the whole of the Docker Official Images, we only had one line-based file that didn't meet this validation, and I've fixed it in https://github.com/docker-library/official-images/commit/79f0bd4bb86b0639ef61f1224c6ce5802830641c.