### PR TITLE
Add "mips64le" in SupportedArches

### DIFF
--- a/architecture/oci-platform.go
+++ b/architecture/oci-platform.go
@@ -1,6 +1,6 @@
 package architecture
 
-// https://github.com/opencontainers/image-spec/blob/v1.0.0-rc6/image-index.md#image-index-property-descriptions
+// https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md#image-index-property-descriptions
 // see "platform" (under "manifests")
 type OCIPlatform struct {
 	OS           string `json:"os"`
@@ -12,14 +12,15 @@ type OCIPlatform struct {
 }
 
 var SupportedArches = map[string]OCIPlatform{
-	"amd64":   {OS: "linux", Architecture: "amd64"},
-	"arm32v5": {OS: "linux", Architecture: "arm", Variant: "v5"},
-	"arm32v6": {OS: "linux", Architecture: "arm", Variant: "v6"},
-	"arm32v7": {OS: "linux", Architecture: "arm", Variant: "v7"},
-	"arm64v8": {OS: "linux", Architecture: "arm64", Variant: "v8"},
-	"i386":    {OS: "linux", Architecture: "386"},
-	"ppc64le": {OS: "linux", Architecture: "ppc64le"},
-	"s390x":   {OS: "linux", Architecture: "s390x"},
+	"amd64":    {OS: "linux", Architecture: "amd64"},
+	"arm32v5":  {OS: "linux", Architecture: "arm", Variant: "v5"},
+	"arm32v6":  {OS: "linux", Architecture: "arm", Variant: "v6"},
+	"arm32v7":  {OS: "linux", Architecture: "arm", Variant: "v7"},
+	"arm64v8":  {OS: "linux", Architecture: "arm64", Variant: "v8"},
+	"i386":     {OS: "linux", Architecture: "386"},
+	"mips64le": {OS: "linux", Architecture: "mips64le"},
+	"ppc64le":  {OS: "linux", Architecture: "ppc64le"},
+	"s390x":    {OS: "linux", Architecture: "s390x"},
 
 	"windows-amd64": {OS: "windows", Architecture: "amd64"},
 }


### PR DESCRIPTION
Looking at https://golang.org/doc/install/source#environment under "GOARCH", this is the accepted Go architecture value for the 64-bit little endian MIPS platform.

This matches the particular MIPS architecture variation being proposed by Loongson in https://github.com/docker-library/hello-world/pull/63.