### PR TITLE
As a first step towards line-based manifest file deprecation, stop returning line-based parsing errors

### DIFF
--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 )
 
@@ -15,7 +14,9 @@ func Parse(reader io.Reader) (*Manifest2822, error) {
 	if err2822 != nil {
 		manifest, err := ParseLineBased(buf)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse manifest in either format:\nRFC 2822 error: %v\nLine-based error: %v", err2822, err)
+			// if we fail parsing line-based, eat the error and return the 2822 parsing error instead
+			// https://github.com/docker-library/bashbrew/issues/16
+			return nil, err2822
 		}
 		return manifest, nil
 	}

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -14,7 +14,7 @@ func TestParseError(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error, got valid manifest instead:\n%s", man)
 	}
-	if !strings.HasPrefix(err.Error(), "cannot parse manifest in either format:") {
+	if !strings.HasPrefix(err.Error(), "Bad line:") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
This is intended as a concrete first step towards https://github.com/docker-library/bashbrew/issues/16.